### PR TITLE
Update Azure_ERvNet_NetSec_Dont_Use_VNet_Peerings - 'EML' zones to the list of approved exempted zones

### DIFF
--- a/Control coverage/Feature/VirtualNetwork.md
+++ b/Control coverage/Feature/VirtualNetwork.md
@@ -351,6 +351,10 @@ A virtual network peering on an ER-connected circuit establishes a link to anoth
         {
             "RemoteNetworkIdPrefix": "",
             "ResourceGroup": "ERNetwork-DB"
+        },
+	{
+            "RemoteNetworkIdPrefix": "",
+            "ResourceGroup": "ERNetwork-EML"
         }
     ]
 }


### PR DESCRIPTION
Update Azure_ERvNet_NetSec_Dont_Use_VNet_Peerings - 'EML' zones to the list of approved exempted zones.