### PR TITLE
Update control evaluation logic documentation.

### DIFF
--- a/Control coverage/Feature/Storage.md
+++ b/Control coverage/Feature/Storage.md
@@ -85,12 +85,12 @@ Use of HTTPS ensures server/service authentication and protects data in transit 
 > **Passed:**
 > Microsoft Defender for Cloud (MDC) reports the assessment status for the storage account as `Healthy`.
 > (or)
-> Storage account supports encryption in transit using HTTPS protocol.
+> Storage account supports encryption in transit using HTTPS protocol or it does not support encryption in transit and has only NFS based file shares.
 >
 > **Failed:**
 > Microsoft Defender for Cloud (MDC) reports the assessment status for the storage account as either `Unhealthy`, or `NotApplicable` with `cause` - `OffByPolicy` or `Exempt`.
 > (or)
-> Storage account does not support encryption in transit using HTTPS protocol.
+> Storage account does not support encryption in transit using HTTPS protocol and it has either no files shares or has both NFS & SMB based file shares
 >
 > **Verify:**
 > Microsoft Defender for Cloud (MDC) reports the assessment status for the storage account as `Not Applicable` with `cause` other than `OffByPolicy` and `Exempt`.
@@ -116,6 +116,7 @@ Use of HTTPS ensures server/service authentication and protects data in transit 
 	```powershell
 	Get-Help Set-AzStorageAccount -full
 	```
+**NOTE:** If your Storage account contains NFS and SMB Fileshares, you would need to move your NFS Fileshares to a separate Storage account that only contains NFS Fileshares. Such Storage accounts would be exempted from evaluation of this security control. Any Storage accounts with SMB fileshare are evaluated for secure transfer with this control.
 
 <!--
 - **Enforcement Policy**

--- a/Control coverage/Feature/Storage.md
+++ b/Control coverage/Feature/Storage.md
@@ -84,13 +84,13 @@ Use of HTTPS ensures server/service authentication and protects data in transit 
 
 > **Passed:**
 > Microsoft Defender for Cloud (MDC) reports the assessment status for the storage account as `Healthy`.
-> (or)
-> Storage account supports encryption in transit using HTTPS protocol or it does not support encryption in transit and has only NFS based file shares.
+> (and) either of below:
+> - Storage account supports encryption in transit using HTTPS protocol.
+> - Storage account has only NFS based file shares (which does not support encryption in transit).
 >
 > **Failed:**
 > Microsoft Defender for Cloud (MDC) reports the assessment status for the storage account as either `Unhealthy`, or `NotApplicable` with `cause` - `OffByPolicy` or `Exempt`.
-> (or)
-> Storage account does not support encryption in transit using HTTPS protocol and it has either no files shares or has both NFS & SMB based file shares
+> (or) Storage account has both NFS & SMB based file shares (Since the NFS File shares do not support encryption in transit, they will have to be moved into a separate storage account in order to be excluded from evaluation)
 >
 > **Verify:**
 > Microsoft Defender for Cloud (MDC) reports the assessment status for the storage account as `Not Applicable` with `cause` other than `OffByPolicy` and `Exempt`.


### PR DESCRIPTION
Control evaluation logic and recommendation is updated based on the latest release of the Azure_Storage_DP_Encrypt_In_Transit control to exclude storage accounts with ONLY NFS file shares