### PR TITLE
Move to latest syntax for action groups

### DIFF
--- a/MMA Removal Utility/DeploymentFiles/MMARemovalUtilitySetup.ps1
+++ b/MMA Removal Utility/DeploymentFiles/MMARemovalUtilitySetup.ps1
@@ -1734,13 +1734,14 @@ function Grant-AzTSMMARemediationIdentityAccessOnKeyVault
                 Write-Host "Creating monitoring alerts..." -ForegroundColor $([Constants]::MessageType.Info) 
                 $EmailReceivers = @()
                 $SendAlertsToEmailIds | ForEach-Object {
-                    $EmailReceivers += New-AzActionGroupReceiver -Name "Notify_$($_)" -EmailReceiver -EmailAddress $_
+		    $EmailReceivers += New-AzActionGroupEmailReceiverObject  -Name "Notify_$($_)" -EmailAddress $_
                 }
 
                 $keyVaultRGName =  $ResourceId.Split("/")[4] # ResourceId is in format - /subscriptions/SubIdGuid/resourceGroups/RGName/providers/Microsoft.KeyVault/vaults/KeyVaultName
-                $alertActionGroupForKV = Set-AzActionGroup -Name 'MMARemovalUtilityActionGroupForKV' -ResourceGroupName $keyVault.ResourceGroupName -ShortName 'MMAKVAlert' -Receiver $EmailReceivers -WarningAction SilentlyContinue
-
-                $deploymentName = "MMARemovalenvironmentmonitoringsetupforkv-$([datetime]::Now.ToString("yyyymmddThhmmss"))"
+                
+		$alertActionGroupForKV = Update-AzActionGroup -Name 'MMARemovalUtilityActionGroupForKV' -ResourceGroupName $keyVault.ResourceGroupName -Name 'MMAKVAlert' -EmailReceiver $EmailReceivers -WarningAction SilentlyContinue
+                
+		$deploymentName = "MMARemovalenvironmentmonitoringsetupforkv-$([datetime]::Now.ToString("yyyymmddThhmmss"))"
 
                 $alertQuery = [string]::Format([Constants]::UnintendedSecretAccessAlertQuery, $ResourceId, $IdentitySecretUri, $UserAssignedIdentityObjectId)
                 $deploymentOutput = New-AzResourceGroupDeployment -Name  $deploymentName `

--- a/MMA Removal Utility/DeploymentFiles/MMARemovalUtilitySetup.ps1
+++ b/MMA Removal Utility/DeploymentFiles/MMARemovalUtilitySetup.ps1
@@ -1739,8 +1739,18 @@ function Grant-AzTSMMARemediationIdentityAccessOnKeyVault
 
                 $keyVaultRGName =  $ResourceId.Split("/")[4] # ResourceId is in format - /subscriptions/SubIdGuid/resourceGroups/RGName/providers/Microsoft.KeyVault/vaults/KeyVaultName
                 
-		$alertActionGroupForKV = Update-AzActionGroup -Name 'MMARemovalUtilityActionGroupForKV' -ResourceGroupName $keyVault.ResourceGroupName -Name 'MMAKVAlert' -EmailReceiver $EmailReceivers -WarningAction SilentlyContinue
-                
+		$alertActionGroupForKV = Get-AzActionGroup -Name ‘MMARemovalUtilityActionGroupForKV’ -ResourceGroupName $keyVaultRGName -ErrorAction SilentlyContinue
+	        if ($null -ne $alertActionGroupForKV) 
+                {
+	            Write-Verbose "Updating existing AzTSAlertActionGroupForKV..."
+                    $alertActionGroupForKV = Update-AzActionGroup -Name ‘MMARemovalUtilityActionGroupForKV’ -ResourceGroupName $keyVaultRGName -GroupShortName ‘MMAKVAlert’ -EmailReceiver $EmailReceivers -WarningAction SilentlyContinue
+                } 
+                else 
+                {
+                    Write-Verbose "Creating new AzTSAlertActionGroupForKV..."
+                    $alertActionGroupForKV = New-AzActionGroup -Name ‘MMARemovalUtilityActionGroupForKV’ -ResourceGroupName $keyVaultRGName -GroupShortName ‘MMAKVAlert’ -Location "Global" -EmailReceiver $EmailReceivers -WarningAction SilentlyContinue
+                }
+		
 		$deploymentName = "MMARemovalenvironmentmonitoringsetupforkv-$([datetime]::Now.ToString("yyyymmddThhmmss"))"
 
                 $alertQuery = [string]::Format([Constants]::UnintendedSecretAccessAlertQuery, $ResourceId, $IdentitySecretUri, $UserAssignedIdentityObjectId)

--- a/TemplateFiles/DeploymentFiles/AzTSSetup.ps1
+++ b/TemplateFiles/DeploymentFiles/AzTSSetup.ps1
@@ -1052,7 +1052,7 @@ function Set-AzTSMonitoringAlert
             $EmailReceivers += New-AzActionGroupEmailReceiverObject -Name "Notify_$($_)" -EmailAddress $_
         }
 	
-	$alertActionGroup  = New-AzActionGroup -Name ‘AzTSAlertActionGroup’ -ResourceGroup $keyVaultRGName     -ShortName ‘AzTSAlert’ -EmailReceiver $EmailReceivers -WarningAction SilentlyContinue
+	$alertActionGroup  = Update-AzActionGroup -Name ‘AzTSAlertActionGroup’ -ResourceGroupName $keyVaultRGName  -ShortName ‘AzTSAlert’ -EmailReceiver $EmailReceivers -WarningAction SilentlyContinue
 
         if($DeploymentResult.Outputs.ContainsKey('logAnalyticsResourceId') -and $DeploymentResult.Outputs.ContainsKey('applicationInsightsId'))
         {
@@ -2101,7 +2101,7 @@ function Grant-AzSKAccessOnKeyVaultToUserAssignedIdentity
                 }
 
                 $keyVaultRGName =  $ResourceId.Split("/")[4] # ResourceId is in format - /subscriptions/SubIdGuid/resourceGroups/RGName/providers/Microsoft.KeyVault/vaults/KeyVaultName
-		$alertActionGroupForKV = New-AzActionGroup -Name ‘AzTSAlertActionGroupForKV’ -ResourceGroup $keyVaultRGName -ShortName ‘AzTSKVAlert’ -EmailReceiver $EmailReceivers -WarningAction SilentlyContinue
+		$alertActionGroupForKV = New-AzActionGroup -Name ‘AzTSAlertActionGroupForKV’ -ResourceGroupName $keyVaultRGName -ShortName ‘AzTSKVAlert’ -EmailReceiver $EmailReceivers -WarningAction SilentlyContinue
                 $deploymentName = "AzTSenvironmentmonitoringsetupforkv-$([datetime]::Now.ToString("yyyymmddThhmmss"))"
 
                 $alertQuery = [string]::Format([Constants]::UnintendedSecretAccessAlertQuery, $ResourceId, $ScanIdentitySecretUri, $UserAssignedIdentityObjectId)

--- a/TemplateFiles/DeploymentFiles/AzTSSetup.ps1
+++ b/TemplateFiles/DeploymentFiles/AzTSSetup.ps1
@@ -1049,11 +1049,10 @@ function Set-AzTSMonitoringAlert
                 
         $EmailReceivers = @()
         $SendAlertNotificationToEmailIds | ForEach-Object {
-            $EmailReceivers += New-AzActionGroupReceiver -Name "Notify_$($_)" -EmailReceiver -EmailAddress $_
+            $EmailReceivers += New-AzActionGroupEmailReceiverObject -Name "Notify_$($_)" -EmailAddress $_
         }
-
-        $alertActionGroup = Set-AzActionGroup -Name ‘AzTSAlertActionGroup’ -ResourceGroupName $ScanHostRGName -ShortName ‘AzTSAlert’ -Receiver $EmailReceivers -WarningAction SilentlyContinue
-
+	
+	$alertActionGroup  = New-AzActionGroup -Name ‘AzTSAlertActionGroup’ -ResourceGroup $keyVaultRGName     -ShortName ‘AzTSAlert’ -EmailReceiver $EmailReceivers -WarningAction SilentlyContinue
 
         if($DeploymentResult.Outputs.ContainsKey('logAnalyticsResourceId') -and $DeploymentResult.Outputs.ContainsKey('applicationInsightsId'))
         {
@@ -2098,12 +2097,11 @@ function Grant-AzSKAccessOnKeyVaultToUserAssignedIdentity
                 Write-Host "Creating monitoring alerts..." -ForegroundColor $([Constants]::MessageType.Info) 
                 $EmailReceivers = @()
                 $SendAlertsToEmailIds | ForEach-Object {
-                    $EmailReceivers += New-AzActionGroupReceiver -Name "Notify_$($_)" -EmailReceiver -EmailAddress $_
+                    $EmailReceivers += New-AzActionGroupEmailReceiverObject -Name "Notify_$($_)" -EmailAddress $_
                 }
 
                 $keyVaultRGName =  $ResourceId.Split("/")[4] # ResourceId is in format - /subscriptions/SubIdGuid/resourceGroups/RGName/providers/Microsoft.KeyVault/vaults/KeyVaultName
-                $alertActionGroupForKV = Set-AzActionGroup -Name ‘AzTSAlertActionGroupForKV’ -ResourceGroupName $keyVaultRGName -ShortName ‘AzTSKVAlert’ -Receiver $EmailReceivers -WarningAction SilentlyContinue
-
+		$alertActionGroupForKV = New-AzActionGroup -Name ‘AzTSAlertActionGroupForKV’ -ResourceGroup $keyVaultRGName -ShortName ‘AzTSKVAlert’ -EmailReceiver $EmailReceivers -WarningAction SilentlyContinue
                 $deploymentName = "AzTSenvironmentmonitoringsetupforkv-$([datetime]::Now.ToString("yyyymmddThhmmss"))"
 
                 $alertQuery = [string]::Format([Constants]::UnintendedSecretAccessAlertQuery, $ResourceId, $ScanIdentitySecretUri, $UserAssignedIdentityObjectId)


### PR DESCRIPTION
Running the AZTS `Install-AzSKTenantSecuritySolution` command displays an error message during operation. It appears to stumble over the creation of the Action Groups for Azure Monitor alerts. 

```
VERBOSE: 16:30:41 - Creating monitoring alerts...
The term 'New-AzActionGroupReceiver' is not recognized as the name of a cmdlet, function, script file, or operable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.                   
```

After researching I found that current Azure Powershell cmdlet's syntax has changed. That being said I took the time to move to the latest syntax to address this error.

**Prior Version**
https://learn.microsoft.com/en-us/powershell/module/az.monitor/new-azactiongroup?view=azps-0.10.0
**New Version**
https://learn.microsoft.com/en-us/powershell/module/az.monitor/new-azactiongroupemailreceiverobject?view=azps-12.1.0