### PR TITLE
Create policy_definition_deny_instalation_deprecated_monitoring_agent_extensions.json

### DIFF
--- a/policy_definition_deny_instalation_deprecated_monitoring_agent_extensions.json
+++ b/policy_definition_deny_instalation_deprecated_monitoring_agent_extensions.json
@@ -1,0 +1,48 @@
+{
+  "name": "Deny-Deprec-Extensions",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "apiVersion": "2021-06-01",
+  "properties": {
+    "policyType": "Custom",
+    "mode": "Indexed",
+    "displayName": "Deny Installation of Deprecated Monitoring Agent Extensions",
+    "description": "This policy denies the installation of Microsoft Monitoring Agent (MMA) and OmsAgentForLinux extensions on any virtual machines.",
+    "metadata": {
+      "version": "1.0.0",
+      "category": "Monitoring",
+      "source": "Custom Policy for Denying Deprecated Monitoring Extensions"
+    },
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "allowedValues": ["Audit", "Deny", "Disabled"],
+        "defaultValue": "Deny",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of the policy"
+        }
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Compute/virtualMachines/extensions"
+          },
+          {
+            "field": "Microsoft.Compute/virtualMachines/extensions/publisher",
+            "equals": "Microsoft.EnterpriseCloud.Monitoring"
+          },
+          {
+            "field": "Microsoft.Compute/virtualMachines/extensions/type",
+            "in": ["MicrosoftMonitoringAgent", "OmsAgentForLinux"]
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This Policy Definition denies the installation of Microsoft Monitoring Agent (MMA) and OmsAgentForLinux extensions on any virtual machines.